### PR TITLE
Enhance tenant search with classification filters

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -12,7 +12,22 @@ CREATE TABLE IF NOT EXISTS tenants (
     contact_email VARCHAR(255) NOT NULL,
     phone VARCHAR(50),
     address TEXT,
+    city VARCHAR(100),
+    state_province VARCHAR(100),
+    country VARCHAR(100),
+    postal_code VARCHAR(20),
     timezone VARCHAR(100) DEFAULT 'UTC',
+    religion VARCHAR(100),
+    tradition VARCHAR(100),
+    denomination VARCHAR(100),
+    sect VARCHAR(100),
+    size_category VARCHAR(50),
+    average_weekly_attendance INTEGER,
+    founded_year INTEGER,
+    languages TEXT[],
+    tags TEXT[],
+    latitude DECIMAL(9,6),
+    longitude DECIMAL(9,6),
     is_active BOOLEAN DEFAULT true,
     settings JSONB DEFAULT '{}',
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -197,6 +212,14 @@ CREATE INDEX IF NOT EXISTS idx_reminder_bells_tenant_id ON reminder_bells(tenant
 CREATE INDEX IF NOT EXISTS idx_staff_posts_tenant_id ON staff_posts(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_layperson_posts_tenant_id ON layperson_posts(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_comments_tenant_id ON comments(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_tenants_religion ON tenants((LOWER(religion)));
+CREATE INDEX IF NOT EXISTS idx_tenants_tradition ON tenants((LOWER(tradition)));
+CREATE INDEX IF NOT EXISTS idx_tenants_denomination ON tenants((LOWER(denomination)));
+CREATE INDEX IF NOT EXISTS idx_tenants_sect ON tenants((LOWER(sect)));
+CREATE INDEX IF NOT EXISTS idx_tenants_city ON tenants((LOWER(city)));
+CREATE INDEX IF NOT EXISTS idx_tenants_state_province ON tenants((LOWER(state_province)));
+CREATE INDEX IF NOT EXISTS idx_tenants_country ON tenants((LOWER(country)));
+CREATE INDEX IF NOT EXISTS idx_tenants_size_category ON tenants((LOWER(size_category)));
 
 -- Function to update the updated_at timestamp
 CREATE OR REPLACE FUNCTION update_updated_at_column()

--- a/database/seed.js
+++ b/database/seed.js
@@ -13,6 +13,18 @@ async function seedDatabase() {
         contactEmail: 'admin@firstcommunity.org',
         phone: '+1-555-0100',
         address: '123 Main Street, Springfield, IL 62701',
+        city: 'Springfield',
+        stateProvince: 'IL',
+        country: 'United States',
+        postalCode: '62701',
+        religion: 'Christianity',
+        tradition: 'Protestant',
+        denomination: 'Non-denominational',
+        sect: 'Evangelical',
+        sizeCategory: 'medium',
+        averageWeeklyAttendance: 450,
+        languages: ['English'],
+        tags: ['family', 'community'],
         admin: {
           email: 'admin@firstcommunity.org',
           firstName: 'Admin',
@@ -27,6 +39,18 @@ async function seedDatabase() {
         contactEmail: 'hello@zengarden.org',
         phone: '+1-555-0200',
         address: '88 Lotus Way, Portland, OR 97205',
+        city: 'Portland',
+        stateProvince: 'OR',
+        country: 'United States',
+        postalCode: '97205',
+        religion: 'Buddhism',
+        tradition: 'Zen',
+        denomination: 'Soto Zen',
+        sect: 'Mahāyāna',
+        sizeCategory: 'small',
+        averageWeeklyAttendance: 120,
+        languages: ['English', 'Japanese'],
+        tags: ['meditation', 'retreat'],
         admin: {
           email: 'abbot@zengarden.org',
           firstName: 'Mei',
@@ -41,6 +65,18 @@ async function seedDatabase() {
         contactEmail: 'connect@sacredpath.com',
         phone: '+1-555-0300',
         address: '450 Sunrise Ridge, Boulder, CO 80302',
+        city: 'Boulder',
+        stateProvince: 'CO',
+        country: 'United States',
+        postalCode: '80302',
+        religion: 'Hinduism',
+        tradition: 'Bhakti',
+        denomination: 'Vaishnavism',
+        sect: 'Gaudiya',
+        sizeCategory: 'medium',
+        averageWeeklyAttendance: 260,
+        languages: ['English', 'Hindi'],
+        tags: ['kirtan', 'yoga'],
         admin: {
           email: 'guide@sacredpath.com',
           firstName: 'Jordan',
@@ -48,15 +84,84 @@ async function seedDatabase() {
           phone: '+1-555-0301',
           password: 'pathfinder'
         }
+      },
+      {
+        name: "St. Mary's Basilica",
+        subdomain: 'stmarys-phoenix',
+        contactEmail: 'info@stmarysbasilica.org',
+        phone: '+1-555-0400',
+        address: '231 N 3rd St, Phoenix, AZ 85004',
+        city: 'Phoenix',
+        stateProvince: 'AZ',
+        country: 'United States',
+        postalCode: '85004',
+        religion: 'Christianity',
+        tradition: 'Roman Catholic',
+        denomination: 'Catholic Church',
+        sect: 'Latin Rite',
+        sizeCategory: 'large',
+        averageWeeklyAttendance: 3200,
+        languages: ['English', 'Spanish'],
+        tags: ['cathedral', 'historic', 'downtown'],
+        admin: {
+          email: 'admin@stmarysbasilica.org',
+          firstName: 'Maria',
+          lastName: 'Lopez',
+          phone: '+1-555-0401',
+          password: 'basilica'
+        }
       }
     ];
 
     for (const tenant of sampleTenants) {
       const tenantResult = await pool.query(
-        `INSERT INTO tenants (name, subdomain, contact_email, phone, address)
-         VALUES ($1, $2, $3, $4, $5)
+        `INSERT INTO tenants (
+           name,
+           subdomain,
+           contact_email,
+           phone,
+           address,
+           city,
+           state_province,
+           country,
+           postal_code,
+           religion,
+           tradition,
+           denomination,
+           sect,
+           size_category,
+           average_weekly_attendance,
+           languages,
+           tags
+         )
+         VALUES (
+           $1, $2, $3, $4, $5,
+           $6, $7, $8, $9,
+           $10, $11, $12, $13,
+           $14, $15,
+           $16::text[],
+           $17::text[]
+         )
          RETURNING id`,
-        [tenant.name, tenant.subdomain, tenant.contactEmail, tenant.phone, tenant.address]
+        [
+          tenant.name,
+          tenant.subdomain,
+          tenant.contactEmail,
+          tenant.phone,
+          tenant.address,
+          tenant.city,
+          tenant.stateProvince,
+          tenant.country,
+          tenant.postalCode,
+          tenant.religion,
+          tenant.tradition,
+          tenant.denomination,
+          tenant.sect,
+          tenant.sizeCategory,
+          tenant.averageWeeklyAttendance,
+          tenant.languages || [],
+          tenant.tags || []
+        ]
       );
 
       const tenantId = tenantResult.rows[0].id;

--- a/src/controllers/tenantController.js
+++ b/src/controllers/tenantController.js
@@ -7,18 +7,69 @@ class TenantController {
         search = '',
         limit = 20,
         offset = 0,
-        includeInactive = 'false'
+        includeInactive = 'false',
+        religions,
+        traditions,
+        denominations,
+        sects,
+        countries,
+        states,
+        cities,
+        sizeCategories,
+        languages,
+        tags,
+        minAttendance,
+        maxAttendance,
+        foundedAfter,
+        foundedBefore
       } = req.query;
 
       const numericLimit = Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100);
       const numericOffset = Math.max(parseInt(offset, 10) || 0, 0);
       const includeInactiveTenants = includeInactive === 'true';
 
+      const parseListParam = value => {
+        if (!value) {
+          return [];
+        }
+
+        const list = Array.isArray(value) ? value : String(value).split(',');
+
+        return list
+          .map(item => (typeof item === 'string' ? item.trim().toLowerCase() : ''))
+          .filter(item => item.length > 0);
+      };
+
+      const parseNumberParam = value => {
+        if (value === undefined || value === null || value === '') {
+          return undefined;
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      };
+
       const results = await Tenant.searchPublic({
         searchTerm: typeof search === 'string' ? search.trim() : '',
         limit: numericLimit,
         offset: numericOffset,
-        includeInactive: includeInactiveTenants
+        includeInactive: includeInactiveTenants,
+        filters: {
+          religions: parseListParam(religions),
+          traditions: parseListParam(traditions),
+          denominations: parseListParam(denominations),
+          sects: parseListParam(sects),
+          countries: parseListParam(countries),
+          states: parseListParam(states),
+          cities: parseListParam(cities),
+          sizeCategories: parseListParam(sizeCategories),
+          languages: parseListParam(languages),
+          tags: parseListParam(tags),
+          minAttendance: parseNumberParam(minAttendance),
+          maxAttendance: parseNumberParam(maxAttendance),
+          foundedAfter: parseNumberParam(foundedAfter),
+          foundedBefore: parseNumberParam(foundedBefore)
+        }
       });
 
       res.json({
@@ -58,7 +109,22 @@ class TenantController {
           contactEmail: tenant.contact_email,
           phone: tenant.phone,
           address: tenant.address,
+          city: tenant.city,
+          stateProvince: tenant.state_province,
+          country: tenant.country,
+          postalCode: tenant.postal_code,
           timezone: tenant.timezone,
+          religion: tenant.religion,
+          tradition: tenant.tradition,
+          denomination: tenant.denomination,
+          sect: tenant.sect,
+          sizeCategory: tenant.size_category,
+          averageWeeklyAttendance: tenant.average_weekly_attendance,
+          foundedYear: tenant.founded_year,
+          languages: tenant.languages,
+          tags: tenant.tags,
+          latitude: tenant.latitude,
+          longitude: tenant.longitude,
           settings: tenant.settings
         }
       });
@@ -70,7 +136,30 @@ class TenantController {
 
   static async create(req, res) {
     try {
-      const { name, subdomain, domain, contactEmail, phone, address } = req.body;
+      const {
+        name,
+        subdomain,
+        domain,
+        contactEmail,
+        phone,
+        address,
+        city,
+        stateProvince,
+        country,
+        postalCode,
+        timezone,
+        religion,
+        tradition,
+        denomination,
+        sect,
+        sizeCategory,
+        averageWeeklyAttendance,
+        foundedYear,
+        languages,
+        tags,
+        latitude,
+        longitude
+      } = req.body;
 
       if (!name || !subdomain || !contactEmail) {
         return res.status(400).json({ error: 'Missing required fields' });
@@ -92,14 +181,61 @@ class TenantController {
         return res.status(409).json({ error: 'Subdomain already taken' });
       }
 
+      const normalizeString = value => (typeof value === 'string' ? value.trim() || null : null);
+      const normalizeLowercaseString = value => (typeof value === 'string' ? value.trim().toLowerCase() || null : null);
+      const normalizeStringArray = value => {
+        if (!value) {
+          return [];
+        }
+
+        const list = Array.isArray(value) ? value : String(value).split(',');
+        return list
+          .map(item => (typeof item === 'string' ? item.trim() : ''))
+          .filter(item => item.length > 0);
+      };
+
+      const normalizeInteger = value => {
+        if (value === undefined || value === null || value === '') {
+          return null;
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? parsed : null;
+      };
+
+      const normalizeFloat = value => {
+        if (value === undefined || value === null || value === '') {
+          return null;
+        }
+
+        const parsed = Number.parseFloat(value);
+        return Number.isFinite(parsed) ? parsed : null;
+      };
+
       // Create tenant
       const tenant = await Tenant.create({
         name: name.trim(),
         subdomain: normalizedSubdomain,
-        domain: domain?.trim().toLowerCase() || null,
+        domain: normalizeLowercaseString(domain),
         contactEmail: contactEmail.trim().toLowerCase(),
-        phone: phone?.trim(),
-        address: address?.trim()
+        phone: normalizeString(phone),
+        address: normalizeString(address),
+        city: normalizeString(city),
+        stateProvince: normalizeString(stateProvince),
+        country: normalizeString(country),
+        postalCode: normalizeString(postalCode),
+        timezone: normalizeString(timezone) || 'UTC',
+        religion: normalizeString(religion),
+        tradition: normalizeString(tradition),
+        denomination: normalizeString(denomination),
+        sect: normalizeString(sect),
+        sizeCategory: normalizeLowercaseString(sizeCategory),
+        averageWeeklyAttendance: normalizeInteger(averageWeeklyAttendance),
+        foundedYear: normalizeInteger(foundedYear),
+        languages: normalizeStringArray(languages),
+        tags: normalizeStringArray(tags),
+        latitude: normalizeFloat(latitude),
+        longitude: normalizeFloat(longitude)
       });
 
       res.status(201).json({
@@ -131,7 +267,22 @@ class TenantController {
         contactEmail: req.tenant.contact_email,
         phone: req.tenant.phone,
         address: req.tenant.address,
+        city: req.tenant.city,
+        stateProvince: req.tenant.state_province,
+        country: req.tenant.country,
+        postalCode: req.tenant.postal_code,
         timezone: req.tenant.timezone,
+        religion: req.tenant.religion,
+        tradition: req.tenant.tradition,
+        denomination: req.tenant.denomination,
+        sect: req.tenant.sect,
+        sizeCategory: req.tenant.size_category,
+        averageWeeklyAttendance: req.tenant.average_weekly_attendance,
+        foundedYear: req.tenant.founded_year,
+        languages: req.tenant.languages,
+        tags: req.tenant.tags,
+        latitude: req.tenant.latitude,
+        longitude: req.tenant.longitude,
         isActive: req.tenant.is_active,
         createdAt: req.tenant.created_at
       });
@@ -147,7 +298,30 @@ class TenantController {
         return res.status(400).json({ error: 'Tenant context required' });
       }
 
-      const allowedUpdates = ['name', 'domain', 'contact_email', 'phone', 'address', 'timezone', 'settings'];
+      const allowedUpdates = [
+        'name',
+        'domain',
+        'contact_email',
+        'phone',
+        'address',
+        'city',
+        'state_province',
+        'country',
+        'postal_code',
+        'timezone',
+        'religion',
+        'tradition',
+        'denomination',
+        'sect',
+        'size_category',
+        'average_weekly_attendance',
+        'founded_year',
+        'languages',
+        'tags',
+        'latitude',
+        'longitude',
+        'settings'
+      ];
       const normalizedBody = { ...req.body };
 
       if (typeof normalizedBody.contactEmail === 'string') {
@@ -169,6 +343,91 @@ class TenantController {
 
       if (typeof normalizedBody.address === 'string') {
         normalizedBody.address = normalizedBody.address.trim();
+      }
+
+      if (typeof normalizedBody.timezone === 'string') {
+        normalizedBody.timezone = normalizedBody.timezone.trim();
+      }
+
+      if (typeof normalizedBody.city === 'string') {
+        normalizedBody.city = normalizedBody.city.trim();
+      }
+
+      if (typeof normalizedBody.stateProvince === 'string') {
+        normalizedBody.state_province = normalizedBody.stateProvince.trim();
+        delete normalizedBody.stateProvince;
+      }
+
+      if (typeof normalizedBody.country === 'string') {
+        normalizedBody.country = normalizedBody.country.trim();
+      }
+
+      if (typeof normalizedBody.postalCode === 'string') {
+        normalizedBody.postal_code = normalizedBody.postalCode.trim();
+        delete normalizedBody.postalCode;
+      }
+
+      if (typeof normalizedBody.religion === 'string') {
+        normalizedBody.religion = normalizedBody.religion.trim();
+      }
+
+      if (typeof normalizedBody.tradition === 'string') {
+        normalizedBody.tradition = normalizedBody.tradition.trim();
+      }
+
+      if (typeof normalizedBody.denomination === 'string') {
+        normalizedBody.denomination = normalizedBody.denomination.trim();
+      }
+
+      if (typeof normalizedBody.sect === 'string') {
+        normalizedBody.sect = normalizedBody.sect.trim();
+      }
+
+      if (typeof normalizedBody.sizeCategory === 'string') {
+        normalizedBody.size_category = normalizedBody.sizeCategory.trim().toLowerCase();
+        delete normalizedBody.sizeCategory;
+      }
+
+      if (normalizedBody.averageWeeklyAttendance !== undefined) {
+        const parsed = Number.parseInt(normalizedBody.averageWeeklyAttendance, 10);
+        normalizedBody.average_weekly_attendance = Number.isFinite(parsed) ? parsed : null;
+        delete normalizedBody.averageWeeklyAttendance;
+      }
+
+      if (normalizedBody.foundedYear !== undefined) {
+        const parsed = Number.parseInt(normalizedBody.foundedYear, 10);
+        normalizedBody.founded_year = Number.isFinite(parsed) ? parsed : null;
+        delete normalizedBody.foundedYear;
+      }
+
+      if (normalizedBody.latitude !== undefined) {
+        const parsed = Number.parseFloat(normalizedBody.latitude);
+        normalizedBody.latitude = Number.isFinite(parsed) ? parsed : null;
+      }
+
+      if (normalizedBody.longitude !== undefined) {
+        const parsed = Number.parseFloat(normalizedBody.longitude);
+        normalizedBody.longitude = Number.isFinite(parsed) ? parsed : null;
+      }
+
+      if (normalizedBody.languages !== undefined) {
+        const list = Array.isArray(normalizedBody.languages)
+          ? normalizedBody.languages
+          : String(normalizedBody.languages)
+              .split(',')
+              .map(item => item.trim())
+              .filter(item => item.length > 0);
+        normalizedBody.languages = list;
+      }
+
+      if (normalizedBody.tags !== undefined) {
+        const list = Array.isArray(normalizedBody.tags)
+          ? normalizedBody.tags
+          : String(normalizedBody.tags)
+              .split(',')
+              .map(item => item.trim())
+              .filter(item => item.length > 0);
+        normalizedBody.tags = list;
       }
 
       const updates = {};
@@ -195,7 +454,22 @@ class TenantController {
           contactEmail: updatedTenant.contact_email,
           phone: updatedTenant.phone,
           address: updatedTenant.address,
-          timezone: updatedTenant.timezone
+          city: updatedTenant.city,
+          stateProvince: updatedTenant.state_province,
+          country: updatedTenant.country,
+          postalCode: updatedTenant.postal_code,
+          timezone: updatedTenant.timezone,
+          religion: updatedTenant.religion,
+          tradition: updatedTenant.tradition,
+          denomination: updatedTenant.denomination,
+          sect: updatedTenant.sect,
+          sizeCategory: updatedTenant.size_category,
+          averageWeeklyAttendance: updatedTenant.average_weekly_attendance,
+          foundedYear: updatedTenant.founded_year,
+          languages: updatedTenant.languages,
+          tags: updatedTenant.tags,
+          latitude: updatedTenant.latitude,
+          longitude: updatedTenant.longitude
         }
       });
     } catch (error) {

--- a/src/models/Tenant.js
+++ b/src/models/Tenant.js
@@ -1,12 +1,86 @@
 const pool = require('../config/database');
 
 class Tenant {
-  static async create({ name, subdomain, domain, contactEmail, phone, address }) {
+  static async create({
+    name,
+    subdomain,
+    domain,
+    contactEmail,
+    phone,
+    address,
+    city,
+    stateProvince,
+    country,
+    postalCode,
+    timezone,
+    religion,
+    tradition,
+    denomination,
+    sect,
+    sizeCategory,
+    averageWeeklyAttendance,
+    foundedYear,
+    languages,
+    tags,
+    latitude,
+    longitude
+  }) {
     const result = await pool.query(
-      `INSERT INTO tenants (name, subdomain, domain, contact_email, phone, address)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO tenants (
+         name,
+         subdomain,
+         domain,
+         contact_email,
+         phone,
+         address,
+         city,
+         state_province,
+         country,
+         postal_code,
+         timezone,
+         religion,
+         tradition,
+         denomination,
+         sect,
+         size_category,
+         average_weekly_attendance,
+         founded_year,
+         languages,
+         tags,
+         latitude,
+         longitude
+       )
+       VALUES (
+         $1, $2, $3, $4, $5, $6,
+         $7, $8, $9, $10, $11,
+         $12, $13, $14, $15, $16,
+         $17, $18, $19::text[], $20::text[], $21, $22
+       )
        RETURNING *`,
-      [name, subdomain, domain, contactEmail, phone, address]
+      [
+        name,
+        subdomain,
+        domain,
+        contactEmail,
+        phone,
+        address,
+        city,
+        stateProvince,
+        country,
+        postalCode,
+        timezone,
+        religion,
+        tradition,
+        denomination,
+        sect,
+        sizeCategory,
+        averageWeeklyAttendance,
+        foundedYear,
+        languages || [],
+        tags || [],
+        latitude,
+        longitude
+      ]
     );
 
     return result.rows[0];
@@ -47,7 +121,11 @@ class Tenant {
 
     Object.keys(updates).forEach(key => {
       fields.push(`${key} = $${paramCount}`);
-      values.push(updates[key]);
+      if (Array.isArray(updates[key])) {
+        values.push(updates[key]);
+      } else {
+        values.push(updates[key]);
+      }
       paramCount++;
     });
 
@@ -61,7 +139,13 @@ class Tenant {
     return result.rows[0];
   }
 
-  static async searchPublic({ searchTerm = '', limit = 20, offset = 0, includeInactive = false } = {}) {
+  static async searchPublic({
+    searchTerm = '',
+    limit = 20,
+    offset = 0,
+    includeInactive = false,
+    filters = {}
+  } = {}) {
     const values = [];
     const conditions = [];
 
@@ -69,25 +153,170 @@ class Tenant {
       conditions.push('is_active = true');
     }
 
-    if (searchTerm) {
-      const likeValue = `%${searchTerm.toLowerCase()}%`;
-      const searchParamIndex = values.length + 1;
-      values.push(likeValue);
-      conditions.push(
-        `(
-          LOWER(name) LIKE $${searchParamIndex}
-          OR LOWER(subdomain) LIKE $${searchParamIndex}
-          OR LOWER(COALESCE(domain, '')) LIKE $${searchParamIndex}
-          OR LOWER(COALESCE(address, '')) LIKE $${searchParamIndex}
-        )`
-      );
+    const sanitizedSearchTerm = typeof searchTerm === 'string' ? searchTerm.toLowerCase().trim() : '';
+
+    if (sanitizedSearchTerm) {
+      const stopWords = new Set(['and', 'or', 'the', 'a', 'an', 'of', 'in', 'at', 'to', 'for']);
+      const tokens = sanitizedSearchTerm
+        .split(/[^\p{L}\p{N}]+/u)
+        .map(token => token.trim())
+        .filter(token => token.length > 0 && !stopWords.has(token));
+
+      const limitedTokens = tokens.slice(0, 10);
+
+      const searchableExpressions = [
+        'COALESCE(name, \'\')',
+        'COALESCE(subdomain, \'\')',
+        'COALESCE(domain, \'\')',
+        'COALESCE(address, \'\')',
+        'COALESCE(city, \'\')',
+        'COALESCE(state_province, \'\')',
+        'COALESCE(country, \'\')',
+        'COALESCE(postal_code, \'\')',
+        'COALESCE(religion, \'\')',
+        'COALESCE(tradition, \'\')',
+        'COALESCE(denomination, \'\')',
+        'COALESCE(sect, \'\')',
+        'COALESCE(size_category, \'\')',
+        "COALESCE(array_to_string(languages, ','), '')",
+        "COALESCE(array_to_string(tags, ','), '')"
+      ];
+
+      if (limitedTokens.length > 0) {
+        limitedTokens.forEach(token => {
+          const likeValue = `%${token}%`;
+          const tokenConditions = [];
+
+          searchableExpressions.forEach(expression => {
+            values.push(likeValue);
+            tokenConditions.push(`LOWER(${expression}) LIKE $${values.length}`);
+          });
+
+          if (tokenConditions.length) {
+            conditions.push(`(${tokenConditions.join(' OR ')})`);
+          }
+        });
+      } else {
+        const likeValue = `%${sanitizedSearchTerm}%`;
+        const fallbackConditions = [];
+
+        searchableExpressions.forEach(expression => {
+          values.push(likeValue);
+          fallbackConditions.push(`LOWER(${expression}) LIKE $${values.length}`);
+        });
+
+        if (fallbackConditions.length) {
+          conditions.push(`(${fallbackConditions.join(' OR ')})`);
+        }
+      }
+    }
+
+    const {
+      religions = [],
+      traditions = [],
+      denominations = [],
+      sects = [],
+      countries = [],
+      states = [],
+      cities = [],
+      sizeCategories = [],
+      languages = [],
+      tags = [],
+      minAttendance,
+      maxAttendance,
+      foundedAfter,
+      foundedBefore
+    } = filters;
+
+    const pushListCondition = (column, list) => {
+      if (!Array.isArray(list) || list.length === 0) {
+        return;
+      }
+
+      values.push(list.map(item => item.toLowerCase()));
+      const paramIndex = values.length;
+      conditions.push(`LOWER(${column}) = ANY($${paramIndex})`);
+    };
+
+    pushListCondition('religion', religions);
+    pushListCondition('tradition', traditions);
+    pushListCondition('denomination', denominations);
+    pushListCondition('sect', sects);
+    pushListCondition('country', countries);
+    pushListCondition('state_province', states);
+    pushListCondition('city', cities);
+    pushListCondition('size_category', sizeCategories);
+
+    if (Array.isArray(languages) && languages.length > 0) {
+      values.push(languages.map(language => language.toLowerCase()));
+      const paramIndex = values.length;
+      conditions.push(`
+        EXISTS (
+          SELECT 1 FROM unnest(COALESCE(languages, ARRAY[]::text[])) AS lang
+          WHERE LOWER(lang) = ANY($${paramIndex})
+        )
+      `);
+    }
+
+    if (Array.isArray(tags) && tags.length > 0) {
+      values.push(tags.map(tag => tag.toLowerCase()));
+      const paramIndex = values.length;
+      conditions.push(`
+        EXISTS (
+          SELECT 1 FROM unnest(COALESCE(tags, ARRAY[]::text[])) AS tag
+          WHERE LOWER(tag) = ANY($${paramIndex})
+        )
+      `);
+    }
+
+    if (Number.isFinite(minAttendance)) {
+      values.push(minAttendance);
+      conditions.push(`average_weekly_attendance >= $${values.length}`);
+    }
+
+    if (Number.isFinite(maxAttendance)) {
+      values.push(maxAttendance);
+      conditions.push(`average_weekly_attendance <= $${values.length}`);
+    }
+
+    if (Number.isFinite(foundedAfter)) {
+      values.push(foundedAfter);
+      conditions.push(`founded_year >= $${values.length}`);
+    }
+
+    if (Number.isFinite(foundedBefore)) {
+      values.push(foundedBefore);
+      conditions.push(`founded_year <= $${values.length}`);
     }
 
     const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
 
     const countQuery = `SELECT COUNT(*) FROM tenants ${whereClause}`;
     const dataQuery = `
-      SELECT id, name, subdomain, domain, contact_email AS "contactEmail", address, timezone
+      SELECT
+        id,
+        name,
+        subdomain,
+        domain,
+        contact_email AS "contactEmail",
+        phone,
+        address,
+        city,
+        state_province AS "stateProvince",
+        country,
+        postal_code AS "postalCode",
+        timezone,
+        religion,
+        tradition,
+        denomination,
+        sect,
+        size_category AS "sizeCategory",
+        average_weekly_attendance AS "averageWeeklyAttendance",
+        founded_year AS "foundedYear",
+        languages,
+        tags,
+        latitude,
+        longitude
       FROM tenants
       ${whereClause}
       ORDER BY name ASC


### PR DESCRIPTION
## Summary
- extend the tenants schema with detailed classification, location, and size fields plus supporting indexes
- seed sample tenants with the new metadata, including a Phoenix Catholic parish example, to exercise richer discovery scenarios
- expand public tenant search to tokenize queries, filter by multiple attributes, and surface the new metadata through the API
- normalize tenant create/update flows to persist and return the additional classification fields

## Testing
- not run (requires configured PostgreSQL instance)

------
https://chatgpt.com/codex/tasks/task_e_68ebab9e0704832da9f1030024d2d326