### PR TITLE
Refine landing flow with search-first entry point

### DIFF
--- a/frontend/src/components/landing/GuestPreview.jsx
+++ b/frontend/src/components/landing/GuestPreview.jsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import TempleSearch from './TempleSearch';
+import AuthModal from '../auth/AuthModal';
+import Button from '../shared/Button';
+
+const GuestPreview = () => {
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/dashboard');
+    }
+  }, [isAuthenticated, navigate]);
+
+  return (
+    <div className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-200/40 via-slate-100 to-rose-100/30" />
+      <div className="absolute inset-x-0 top-0 -z-10 h-[60vh] bg-gradient-to-b from-white via-transparent to-transparent" />
+
+      <section className="container mx-auto px-4 py-20 lg:py-28">
+        <div className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr] items-center">
+          <div className="relative">
+            <div className="absolute -top-8 -left-10 h-32 w-32 rounded-full bg-gradient-to-br from-indigo-500/40 to-purple-500/20 blur-3xl" />
+            <span className="inline-flex items-center rounded-full border border-indigo-200 bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 shadow-lg shadow-indigo-200/40 backdrop-blur">
+              Modern rituals for digital communities
+            </span>
+            <h1 className="mt-6 text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-slate-900 leading-tight">
+              Cultivate sacred connection with a luminous digital sanctuary.
+            </h1>
+            <p className="mt-6 text-lg text-slate-600">
+              Temple3 elevates tenant-based spiritual communities with immersive storytelling, guided programming, and a welcoming portal that feels alive.
+            </p>
+            <div className="mt-10 flex flex-col sm:flex-row gap-4">
+              <Button
+                variant="primary"
+                size="lg"
+                className="bg-gradient-to-r from-indigo-500 via-purple-500 to-blue-500 hover:from-indigo-600 hover:via-purple-600 hover:to-blue-600 shadow-xl shadow-indigo-200/60 border border-white/40"
+                onClick={() => setShowAuthModal(true)}
+              >
+                Enter Temple Portal
+              </Button>
+              <button
+                onClick={() => setShowAuthModal(true)}
+                className="inline-flex items-center justify-center rounded-full border border-indigo-200/70 bg-white/60 px-6 py-3 text-base font-medium text-indigo-600 shadow-lg shadow-indigo-100/70 backdrop-blur transition hover:-translate-y-0.5"
+              >
+                Preview Experience
+              </button>
+            </div>
+            <div className="mt-12 grid grid-cols-3 gap-6 text-center text-sm text-slate-600">
+              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
+                <p className="text-3xl font-semibold text-indigo-600">+42%</p>
+                <p className="mt-1 text-xs uppercase tracking-widest">Engagement lift</p>
+              </div>
+              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
+                <p className="text-3xl font-semibold text-indigo-600">24/7</p>
+                <p className="mt-1 text-xs uppercase tracking-widest">Guided rituals</p>
+              </div>
+              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
+                <p className="text-3xl font-semibold text-indigo-600">∞</p>
+                <p className="mt-1 text-xs uppercase tracking-widest">Tenant expressions</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="relative">
+            <div className="absolute -right-12 top-8 h-64 w-64 rounded-full bg-gradient-to-bl from-rose-400/40 to-purple-500/20 blur-3xl" />
+            <div className="relative rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-indigo-200/60 backdrop-blur-xl">
+              <div className="rounded-2xl border border-indigo-100/60 bg-gradient-to-br from-indigo-500 via-purple-500 to-blue-500 p-6 text-white">
+                <h2 className="text-xl font-semibold">Find your Temple</h2>
+                <p className="mt-2 text-sm text-indigo-100">
+                  Discover spaces aligned with your practices and join curated circles instantly.
+                </p>
+                <div className="mt-6 bg-white/15 rounded-2xl p-4 shadow-inner shadow-indigo-900/20">
+                  <TempleSearch />
+                </div>
+              </div>
+              <div className="mt-8 grid gap-4">
+                {[{
+                  title: 'Live ceremony streaming',
+                  description: 'Crystal-clear broadcasts with integrated participation moments.',
+                }, {
+                  title: 'Living library collections',
+                  description: 'Glassmorphic readers bring sacred texts and audio commentaries together.',
+                }, {
+                  title: 'Community constellations',
+                  description: 'Map members, mentors, and guides with shimmering presence indicators.',
+                }].map((item) => (
+                  <div
+                    key={item.title}
+                    className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow-lg shadow-indigo-100/60 backdrop-blur"
+                  >
+                    <h3 className="text-sm font-semibold text-slate-800">{item.title}</h3>
+                    <p className="mt-1 text-xs text-slate-500">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="container mx-auto px-4 pb-24">
+        <div className="rounded-3xl border border-white/60 bg-white/70 p-10 shadow-2xl shadow-indigo-100/60 backdrop-blur">
+          <div className="grid gap-10 md:grid-cols-3">
+            {[{
+              title: 'Adaptive tenant theming',
+              description: 'Glass-inspired palettes blend with each temple’s identity automatically.',
+            }, {
+              title: 'Mindful micro-interactions',
+              description: 'Soothing animations guide your community through rituals and tasks.',
+            }, {
+              title: 'Accessible by design',
+              description: 'High-contrast, keyboard-friendly navigation keeps the sanctuary open to all.',
+            }].map((item) => (
+              <div key={item.title} className="flex flex-col gap-3">
+                <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-indigo-500 via-purple-500 to-blue-500 text-white flex items-center justify-center text-lg font-semibold shadow-lg shadow-indigo-200/70">
+                  ✶
+                </div>
+                <h3 className="text-lg font-semibold text-slate-900">{item.title}</h3>
+                <p className="text-sm text-slate-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Auth Modal */}
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        initialMode="login"
+      />
+    </div>
+  );
+};
+
+export default GuestPreview;

--- a/frontend/src/components/landing/LandingPage.jsx
+++ b/frontend/src/components/landing/LandingPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
 import TempleSearch from './TempleSearch';
 import AuthModal from '../auth/AuthModal';
 import Button from '../shared/Button';
@@ -8,6 +9,7 @@ import Button from '../shared/Button';
 const LandingPage = () => {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const { isAuthenticated } = useAuth();
+  const { currentTenant, tenantData } = useTenant();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -16,119 +18,56 @@ const LandingPage = () => {
     }
   }, [isAuthenticated, navigate]);
 
+  const handleContinueAsGuest = () => {
+    navigate('/experience');
+  };
+
   return (
-    <div className="relative overflow-hidden">
-      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-indigo-200/40 via-slate-100 to-rose-100/30" />
-      <div className="absolute inset-x-0 top-0 -z-10 h-[60vh] bg-gradient-to-b from-white via-transparent to-transparent" />
+    <div className="relative flex min-h-[70vh] items-center justify-center px-4 py-24">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-white via-slate-50 to-white" />
+      <div className="relative w-full max-w-3xl space-y-12 text-center">
+        <div className="space-y-4">
+          <h1 className="text-5xl font-semibold tracking-tight text-slate-900 sm:text-6xl">Temple</h1>
+          <p className="text-lg text-slate-500 sm:text-xl">Find your temple.</p>
+        </div>
 
-      <section className="container mx-auto px-4 py-20 lg:py-28">
-        <div className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr] items-center">
-          <div className="relative">
-            <div className="absolute -top-8 -left-10 h-32 w-32 rounded-full bg-gradient-to-br from-indigo-500/40 to-purple-500/20 blur-3xl" />
-            <span className="inline-flex items-center rounded-full border border-indigo-200 bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-indigo-600 shadow-lg shadow-indigo-200/40 backdrop-blur">
-              Modern rituals for digital communities
-            </span>
-            <h1 className="mt-6 text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-slate-900 leading-tight">
-              Cultivate sacred connection with a luminous digital sanctuary.
-            </h1>
-            <p className="mt-6 text-lg text-slate-600">
-              Temple3 elevates tenant-based spiritual communities with immersive storytelling, guided programming, and a welcoming portal that feels alive.
+        <div className="flex flex-col items-center gap-4">
+          <TempleSearch />
+          <p className="text-sm text-slate-400">
+            Search by community name or location to choose the tenant you belong to.
+          </p>
+          {currentTenant && (
+            <p className="text-sm text-slate-500">
+              Connected to <span className="font-medium text-slate-700">{tenantData?.name || currentTenant}</span>
             </p>
-            <div className="mt-10 flex flex-col sm:flex-row gap-4">
-              <Button
-                variant="primary"
-                size="lg"
-                className="bg-gradient-to-r from-indigo-500 via-purple-500 to-blue-500 hover:from-indigo-600 hover:via-purple-600 hover:to-blue-600 shadow-xl shadow-indigo-200/60 border border-white/40"
-                onClick={() => setShowAuthModal(true)}
-              >
-                Enter Temple Portal
-              </Button>
-              <button
-                onClick={() => setShowAuthModal(true)}
-                className="inline-flex items-center justify-center rounded-full border border-indigo-200/70 bg-white/60 px-6 py-3 text-base font-medium text-indigo-600 shadow-lg shadow-indigo-100/70 backdrop-blur transition hover:-translate-y-0.5"
-              >
-                Preview Experience
-              </button>
-            </div>
-            <div className="mt-12 grid grid-cols-3 gap-6 text-center text-sm text-slate-600">
-              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
-                <p className="text-3xl font-semibold text-indigo-600">+42%</p>
-                <p className="mt-1 text-xs uppercase tracking-widest">Engagement lift</p>
-              </div>
-              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
-                <p className="text-3xl font-semibold text-indigo-600">24/7</p>
-                <p className="mt-1 text-xs uppercase tracking-widest">Guided rituals</p>
-              </div>
-              <div className="rounded-3xl border border-white/60 bg-white/70 px-4 py-6 shadow-lg shadow-indigo-100/60 backdrop-blur">
-                <p className="text-3xl font-semibold text-indigo-600">∞</p>
-                <p className="mt-1 text-xs uppercase tracking-widest">Tenant expressions</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="relative">
-            <div className="absolute -right-12 top-8 h-64 w-64 rounded-full bg-gradient-to-bl from-rose-400/40 to-purple-500/20 blur-3xl" />
-            <div className="relative rounded-3xl border border-white/60 bg-white/80 p-6 shadow-2xl shadow-indigo-200/60 backdrop-blur-xl">
-              <div className="rounded-2xl border border-indigo-100/60 bg-gradient-to-br from-indigo-500 via-purple-500 to-blue-500 p-6 text-white">
-                <h2 className="text-xl font-semibold">Find your Temple</h2>
-                <p className="mt-2 text-sm text-indigo-100">
-                  Discover spaces aligned with your practices and join curated circles instantly.
-                </p>
-                <div className="mt-6 bg-white/15 rounded-2xl p-4 shadow-inner shadow-indigo-900/20">
-                  <TempleSearch />
-                </div>
-              </div>
-              <div className="mt-8 grid gap-4">
-                {[{
-                  title: 'Live ceremony streaming',
-                  description: 'Crystal-clear broadcasts with integrated participation moments.',
-                }, {
-                  title: 'Living library collections',
-                  description: 'Glassmorphic readers bring sacred texts and audio commentaries together.',
-                }, {
-                  title: 'Community constellations',
-                  description: 'Map members, mentors, and guides with shimmering presence indicators.',
-                }].map((item) => (
-                  <div
-                    key={item.title}
-                    className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow-lg shadow-indigo-100/60 backdrop-blur"
-                  >
-                    <h3 className="text-sm font-semibold text-slate-800">{item.title}</h3>
-                    <p className="mt-1 text-xs text-slate-500">{item.description}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
+          )}
         </div>
-      </section>
 
-      <section className="container mx-auto px-4 pb-24">
-        <div className="rounded-3xl border border-white/60 bg-white/70 p-10 shadow-2xl shadow-indigo-100/60 backdrop-blur">
-          <div className="grid gap-10 md:grid-cols-3">
-            {[{
-              title: 'Adaptive tenant theming',
-              description: 'Glass-inspired palettes blend with each temple’s identity automatically.',
-            }, {
-              title: 'Mindful micro-interactions',
-              description: 'Soothing animations guide your community through rituals and tasks.',
-            }, {
-              title: 'Accessible by design',
-              description: 'High-contrast, keyboard-friendly navigation keeps the sanctuary open to all.',
-            }].map((item) => (
-              <div key={item.title} className="flex flex-col gap-3">
-                <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-indigo-500 via-purple-500 to-blue-500 text-white flex items-center justify-center text-lg font-semibold shadow-lg shadow-indigo-200/70">
-                  ✶
-                </div>
-                <h3 className="text-lg font-semibold text-slate-900">{item.title}</h3>
-                <p className="text-sm text-slate-600">{item.description}</p>
-              </div>
-            ))}
-          </div>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+          <Button
+            onClick={() => setShowAuthModal(true)}
+            variant="primary"
+            size="md"
+            className="rounded-full px-8 py-3 text-base shadow-sm"
+          >
+            Log in
+          </Button>
+          <Button
+            onClick={handleContinueAsGuest}
+            variant="outline"
+            size="md"
+            className="rounded-full px-8 py-3 text-base"
+          >
+            Continue as guest
+          </Button>
         </div>
-      </section>
 
-      {/* Auth Modal */}
+        <div className="space-y-2 text-xs text-slate-400">
+          <p>Log in to unlock your personalized tenant experience.</p>
+          <p>Guest access lets you preview Temple without joining a community.</p>
+        </div>
+      </div>
+
       <AuthModal
         isOpen={showAuthModal}
         onClose={() => setShowAuthModal(false)}

--- a/frontend/src/components/landing/TempleSearch.jsx
+++ b/frontend/src/components/landing/TempleSearch.jsx
@@ -74,7 +74,7 @@ const TempleSearch = () => {
           onChange={(e) => setSearchTerm(e.target.value)}
           onFocus={() => searchTerm.length >= 2 && setShowDropdown(true)}
           placeholder="Search for your temple..."
-          className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-lg"
+          className="block w-full rounded-full border border-transparent bg-white px-10 py-4 text-lg leading-5 shadow-[0_10px_40px_-30px_rgba(15,23,42,0.6)] placeholder-gray-400 focus:border-slate-200 focus:outline-none focus:ring-4 focus:ring-indigo-100"
         />
         {loading && (
           <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
@@ -84,19 +84,19 @@ const TempleSearch = () => {
       </div>
 
       {showDropdown && suggestions.length > 0 && (
-        <div className="absolute z-10 w-full mt-2 bg-white rounded-lg shadow-lg border border-gray-200 max-h-96 overflow-auto">
+        <div className="absolute z-10 mt-3 w-full overflow-auto rounded-2xl border border-slate-100 bg-white/95 shadow-2xl shadow-slate-200/70 backdrop-blur max-h-96">
           {suggestions.map((temple) => (
             <button
               key={temple.id}
               onClick={() => handleSelectTemple(temple)}
-              className="w-full px-4 py-3 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none border-b border-gray-100 last:border-b-0"
+              className="w-full px-5 py-3 text-left transition hover:bg-indigo-50/70 focus:bg-indigo-50/70 focus:outline-none border-b border-slate-100 last:border-b-0"
             >
               <div className="font-medium text-gray-900">{temple.name}</div>
               {temple.subdomain && (
-                <div className="text-sm text-gray-500">@{temple.subdomain}</div>
+                <div className="text-sm text-slate-500">@{temple.subdomain}</div>
               )}
               {temple.address && (
-                <div className="text-xs text-gray-400 mt-1">{temple.address}</div>
+                <div className="mt-1 text-xs text-slate-400">{temple.address}</div>
               )}
             </button>
           ))}
@@ -104,9 +104,9 @@ const TempleSearch = () => {
       )}
 
       {showDropdown && searchTerm.length >= 2 && suggestions.length === 0 && !loading && (
-        <div className="absolute z-10 w-full mt-2 bg-white rounded-lg shadow-lg border border-gray-200 p-4 text-center">
-          <p className="text-gray-600">No temples found matching "{searchTerm}"</p>
-          <p className="text-sm text-gray-500 mt-2">Try a different search term or create a new temple</p>
+        <div className="absolute z-10 mt-3 w-full rounded-2xl border border-slate-100 bg-white/95 p-5 text-center shadow-2xl shadow-slate-200/70 backdrop-blur">
+          <p className="text-sm font-medium text-slate-700">No temples found matching "{searchTerm}"</p>
+          <p className="mt-2 text-sm text-slate-500">Try a different search term or create a new temple</p>
         </div>
       )}
     </div>

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from './hooks/useAuth';
 import Layout from './components/layout/Layout';
 import LandingPage from './components/landing/LandingPage';
+import GuestPreview from './components/landing/GuestPreview';
 import Dashboard from './components/dashboard/Dashboard';
 import Calendar from './components/features/calendar/Calendar';
 import Posts from './components/features/posts/Posts';
@@ -48,6 +49,10 @@ export const router = createBrowserRouter([
       {
         path: '/',
         element: <LandingPage />,
+      },
+      {
+        path: '/experience',
+        element: <GuestPreview />,
       },
       {
         path: '/dashboard',


### PR DESCRIPTION
## Summary
- simplify the main landing page into a centered Temple search with clear login and guest actions
- refresh the temple search component styling for a Google-like experience and surface the selected tenant state
- add a guest preview route that preserves the immersive marketing hero for non-authenticated exploration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ec00fa183c832db4b6be8491e29ab1