### PR TITLE
Add tenant control panel guards and server-safe post fetching

### DIFF
--- a/app/components/tenant/ControlPanel.tsx
+++ b/app/components/tenant/ControlPanel.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+type Tenant = {
+  id: string;
+  name?: string;
+};
+
+type User = {
+  id?: string;
+  isSuperAdmin?: boolean;
+  roles?: string[];
+};
+
+type ControlPanelProps = {
+  tenant: Tenant;
+  currentUser?: User | null;
+  onUpdate?: () => void;
+  onImpersonate?: (userId: string) => void;
+  onRefresh?: () => void;
+};
+
+const hasTenantAdminRole = (user: User | null | undefined, tenantId: string) => {
+  if (!user?.roles) return false;
+  return user.roles.includes(`tenant:${tenantId}:admin`) || user.roles.includes('admin');
+};
+
+const ControlPanel: React.FC<ControlPanelProps> = ({
+  tenant,
+  currentUser,
+  onUpdate,
+  onImpersonate,
+  onRefresh
+}) => {
+  const isAdmin = useMemo(() => {
+    if (!tenant?.id) return false;
+    const isSuperAdmin = Boolean(currentUser?.isSuperAdmin);
+    const hasAdminRole = hasTenantAdminRole(currentUser, tenant.id);
+    return isSuperAdmin || hasAdminRole;
+  }, [currentUser, tenant?.id]);
+
+  const heading = tenant?.name ? `${tenant.name} Control Panel` : 'Tenant Control Panel';
+
+  if (!currentUser) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Sign in to manage this tenant. Administrative controls remain hidden until we can verify your role.
+        </p>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-900">
+        <h2 className="text-lg font-semibold">Limited access</h2>
+        <p className="mt-2 text-sm">
+          You need tenant admin or super-admin privileges to configure settings. Ask an administrator to update your role.
+        </p>
+        <div className="mt-4 flex gap-2">
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="rounded-lg bg-white/80 px-3 py-2 text-sm font-medium text-amber-900 shadow-sm ring-1 ring-amber-200 hover:bg-white"
+            >
+              Refresh access
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Tenant</p>
+          <h2 className="text-xl font-semibold text-slate-900">{heading}</h2>
+          <p className="text-sm text-slate-600">Configure membership, branding, and permissions for this tenant.</p>
+        </div>
+        <div className="flex gap-2">
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="rounded-lg bg-slate-100 px-3 py-2 text-sm font-medium text-slate-800 hover:bg-slate-200"
+            >
+              Refresh data
+            </button>
+          )}
+          {onUpdate && (
+            <button
+              type="button"
+              onClick={onUpdate}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700"
+            >
+              Save changes
+            </button>
+          )}
+        </div>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-slate-100 bg-slate-50/80 p-4">
+          <h3 className="text-sm font-semibold text-slate-900">Membership</h3>
+          <p className="mt-1 text-sm text-slate-600">Invite members, assign roles, and manage access.</p>
+          {onImpersonate && (
+            <button
+              type="button"
+              onClick={() => onImpersonate('')}
+              className="mt-3 text-sm font-medium text-indigo-600 hover:text-indigo-700"
+            >
+              Impersonate user
+            </button>
+          )}
+        </div>
+        <div className="rounded-lg border border-slate-100 bg-slate-50/80 p-4">
+          <h3 className="text-sm font-semibold text-slate-900">Branding</h3>
+          <p className="mt-1 text-sm text-slate-600">Update tenant identity and appearance.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ControlPanel;

--- a/app/components/tenant/PostsPage.tsx
+++ b/app/components/tenant/PostsPage.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { getPostsForTenant, Post } from '../../../lib/data';
+
+interface PostsPageProps {
+  tenantId: string;
+}
+
+const PostsPage: React.FC<PostsPageProps> = ({ tenantId }) => {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await getPostsForTenant(tenantId);
+        if (mounted) {
+          setPosts(data);
+        }
+      } catch (err: any) {
+        if (mounted) {
+          setError(err?.message || 'Unable to load posts for this tenant.');
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    if (tenantId) {
+      load();
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [tenantId]);
+
+  const sortedPosts = useMemo(() => {
+    return [...posts].sort((a, b) => {
+      const aDate = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
+      const bDate = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
+      return bDate - aDate;
+    });
+  }, [posts]);
+
+  if (loading) {
+    return <div className="p-6">Loading posts…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 text-rose-900">
+        <p className="font-semibold">Unable to load posts</p>
+        <p className="text-sm mt-1">{error}</p>
+      </div>
+    );
+  }
+
+  if (sortedPosts.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white/80 p-6 text-slate-700">
+        <p className="font-semibold">No posts available</p>
+        <p className="text-sm mt-1">Published posts will appear here once they exist for this tenant.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {sortedPosts.map((post) => (
+        <article key={post.id} className="rounded-xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+          <header className="mb-2 flex items-center justify-between text-sm text-slate-500">
+            <span>{post.author ?? 'Unknown author'}</span>
+            {post.publishedAt && <time dateTime={post.publishedAt}>{new Date(post.publishedAt).toLocaleString()}</time>}
+          </header>
+          <h3 className="text-lg font-semibold text-slate-900">{post.title || 'Untitled post'}</h3>
+          <p className="mt-2 whitespace-pre-wrap text-slate-700">{post.content}</p>
+        </article>
+      ))}
+    </div>
+  );
+};
+
+export default PostsPage;

--- a/app/tenants/[tenantId]/settings/page.tsx
+++ b/app/tenants/[tenantId]/settings/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import ControlPanel from '../../../components/tenant/ControlPanel';
+import PostsPage from '../../../components/tenant/PostsPage';
+
+interface PageProps {
+  params: { tenantId: string };
+}
+
+export default function TenantSettingsPage({ params }: PageProps) {
+  const tenant = { id: params.tenantId };
+  const currentUser = null;
+
+  return (
+    <div className="space-y-8 p-6">
+      <ControlPanel
+        tenant={tenant}
+        currentUser={currentUser}
+        onRefresh={() => window.location.reload()}
+      />
+      <PostsPage tenantId={tenant.id} />
+    </div>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,41 @@
+export type Post = {
+  id: string;
+  title?: string;
+  content: string;
+  publishedAt?: string;
+  author?: string;
+};
+
+const resolveApiBase = () => {
+  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
+  if (typeof window !== 'undefined') {
+    return '';
+  }
+  return process.env.API_URL || 'http://localhost:3000';
+};
+
+export async function getPostsForTenant(tenantId: string): Promise<Post[]> {
+  const apiBase = resolveApiBase();
+  const url = `${apiBase}/api/tenants/${encodeURIComponent(tenantId)}/posts`;
+  const response = await fetch(url, {
+    method: 'GET',
+    cache: 'no-store',
+    headers: { Accept: 'application/json' }
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load posts for tenant');
+  }
+
+  const data = await response.json();
+  const posts = Array.isArray(data?.posts) ? data.posts : data;
+  return posts.map((post: any) => ({
+    id: String(post.id ?? crypto.randomUUID()),
+    title: post.title ?? post.heading ?? '',
+    content: post.content ?? '',
+    publishedAt: post.publishedAt ?? post.published_at ?? null,
+    author: post.author ?? post.authorName ?? 'Unknown'
+  }));
+}


### PR DESCRIPTION
## Summary
- add a tenant control panel component that safely handles missing or unauthorized users
- load tenant posts via an API-backed helper instead of Prisma so the browser bundle stays clean
- wire the tenant settings page to use the guarded control panel and post list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b43a27ad4832da5aeecf66ff62eb9)